### PR TITLE
Remove padding-bottom on last Step child

### DIFF
--- a/packages/css/src/components/steps.css
+++ b/packages/css/src/components/steps.css
@@ -1,4 +1,7 @@
 .f-step {
+    &:last-child > *:last-child {
+        padding-bottom: 0;
+    }
     &.step-v {
         grid-template-rows: 20px auto;
     }


### PR DESCRIPTION
Removing the padding as shown in the image below for the steps component.

![image](https://user-images.githubusercontent.com/16625915/125911795-02bbb457-e96f-4a6c-b2be-ac75ed57ce6b.png)
