### PR TITLE
Fix button--small's bad DX

### DIFF
--- a/packages/css/src/components/button.css
+++ b/packages/css/src/components/button.css
@@ -85,7 +85,15 @@ a.button:hover {
 
 /* Sizing */
 .button--small {
-    @apply px-16 py-8 text-12 leading-16;
+    @apply px-16 py-6 text-12 leading-16;
+}
+
+.button--small.button--primary,
+.button--small.button--destructive,
+.button--small.button--destructive-flat,
+.button--small.button--order,
+.button--small.button--tertiary {
+    @apply py-8;
 }
 
 .button--small.button--secondary {


### PR DESCRIPTION
This bloats the CSS file just barely, but should be worth it as people (including the Fabric devs) have incorrectly assumed that `button button--small` would do the right thing. :D