### PR TITLE
Expose primatives

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,15 +4,20 @@
   "version": "1.1.11-next.1",
   "files": [
     "dist",
-    "src/utils/tailwind",
-    "src/utils/component-classes"
+    "src"
   ],
   "type": "module",
   "style": "dist/fabric.min.css",
   "exports": {
     ".": "./dist/fabric.min.css",
     "./tailwind-config": "./src/utils/tailwind/tailwind.config.js",
-    "./component-classes": "./src/utils/component-classes/index.js"
+    "./component-classes": "./src/utils/component-classes/index.js",
+    "./component-classes/list.js": "./src/utils/component-classes/list.js",
+    "./base.css": "./src/base.css",
+    "./components.css": "./components.css",
+    "./utilities.css": "./utilities.css",
+    "./theme.css": "./theme.css",
+    "./colors.js": "./src/utils/tailwind/colors.js"
   },
   "typesVersions": {
     "*": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "./component-classes": "./src/utils/component-classes/index.js",
     "./component-classes/list.js": "./src/utils/component-classes/list.js",
     "./base.css": "./src/base.css",
-    "./components.css": "./components.css",
-    "./utilities.css": "./utilities.css",
-    "./theme.css": "./theme.css",
+    "./components.css": "./src/components.css",
+    "./utilities.css": "./src/utilities.css",
+    "./theme.css": "./src/theme.css",
     "./colors.js": "./src/utils/tailwind/colors.js"
   },
   "typesVersions": {

--- a/src/utils/component-classes/list.js
+++ b/src/utils/component-classes/list.js
@@ -1,0 +1,8 @@
+import * as components from './index.js';
+
+export const classes = Object.values(components)
+    .map((e) => {
+        if (typeof e === 'object') return Object.values(e).map((e) => e.split(/\s/));
+        return e.split(/\s/);
+    })
+    .flat(Infinity);


### PR DESCRIPTION
This PR exposes some css and js primitives to make it possible for other libraries to create a build using purge.
Testing locally, I was able to use this to successfully create a 40kb CSS build for inlining in `@fabric-ds/elements`.

